### PR TITLE
show navbar on specific pages as Home

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
         <NextAuthProvider>
           <ErudaProvider>
             <MiniKitProvider>
-              {(pathname === "/home" || pathname === "/categories" || pathname === "/categories" || pathname === "/completed" || pathname === "/settings") && <Navbar />}
+              {(pathname === "/home" || pathname === "/categories" || pathname === "/completed" || pathname === "/settings") && <Navbar />}
               {children}
             </MiniKitProvider>
           </ErudaProvider> 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   const pathname = usePathname();
 
   // List of routes where the Navbar will not be shown
-  const hideNavbarRoutes = ["/onboarding/weight", "/SignIn"];
+  //const hideNavbarRoutes = ["/onboarding/weight", "/SignIn"];
 
   return (
     <html lang="en">
@@ -33,10 +33,10 @@ export default function RootLayout({
         <NextAuthProvider>
           <ErudaProvider>
             <MiniKitProvider>
-              {!hideNavbarRoutes.includes(pathname) && <Navbar />}
+              {(pathname === "/home" || pathname === "/categories" || pathname === "/categories" || pathname === "/completed" || pathname === "/settings") && <Navbar />}
               {children}
             </MiniKitProvider>
-          </ErudaProvider>
+          </ErudaProvider> 
         </NextAuthProvider>
       </body>
     </html>


### PR DESCRIPTION
# 📝Show navbar on specific pages as Home

## 🛠️ Issue
- Closes #39 

## 📚 Description
- Only show navbar on pages home, categories, completed, settings according to the figma design.

## ✅ Changes applied
- I have commented out the const hideNavbarRoutes because I modified the logic to ensure that the Navbar is displayed only on some routes. 

## 🔍 Evidence/Media (screenshots/videos)
- 
<img width="258" alt="Screenshot 2025-01-23 at 10 03 11 PM" src="https://github.com/user-attachments/assets/f687e394-d706-460d-8efc-03053d3b41b7" />
<img width="259" alt="Screenshot 2025-01-23 at 10 03 26 PM" src="https://github.com/user-attachments/assets/e071af2f-fc1c-43e3-a534-f5d79e111c92" />
